### PR TITLE
Removed unnecessary requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 beautifulsoup4
-couchdb
-pyyaml
 pytest


### PR DESCRIPTION
These requirements seem to be lies. The DB functionalities have previously been stripped from flowcell_parser.